### PR TITLE
Workaround for setuptools v53.1.0 breaking chage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@
 # https://packaging.python.org/specifications/core-metadata/
 # https://www.python.org/dev/peps/pep-0639/
 # SPDX license short-form identifier, https://spdx.org/licenses/
-# setuptools v53.1.0 no longer recognizes capitilized keys, e.g. "Name" must be "name".
+# setuptools v53.1.0 no longer recognizes capitalized keys, e.g. "Name" must be "name".
 
 metadata-version: 2.2
 name = disorder
@@ -23,7 +23,7 @@ license = Apache-2.0
 license-file = LICENSE
 
 # https://pypi.org/classifiers/
-Classifiers=
+classifiers=
     Development Status :: 4 - Beta
     Intended Audience :: Developers
     Intended Audience :: Science/Research

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,8 @@
 # SPDX license short-form identifier, https://spdx.org/licenses/
 
 Metadata-Version: 2.2
-Name = disorder
+# setuptools v53.1.0 no longer recognizes "Name" key. Must be "name".
+name = disorder
 Summary = Python package for nonequilibrium thermodynamic calculations
 Long-Description = file:README.md
 Long-Description-Content-Type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,19 +8,19 @@
 # https://packaging.python.org/specifications/core-metadata/
 # https://www.python.org/dev/peps/pep-0639/
 # SPDX license short-form identifier, https://spdx.org/licenses/
+# setuptools v53.1.0 no longer recognizes capitilized keys, e.g. "Name" must be "name".
 
-Metadata-Version: 2.2
-# setuptools v53.1.0 no longer recognizes "Name" key. Must be "name".
+metadata-version: 2.2
 name = disorder
-Summary = Python package for nonequilibrium thermodynamic calculations
-Long-Description = file:README.md
-Long-Description-Content-Type = text/markdown
-Keywords = python
-Home-page = https://github.com/gecrooks/disorder/
-Author = Gavin E. Crooks
-Author-email = gec@threeplusone.com
-License = Apache-2.0
-License-File = LICENSE
+summary = Python package for nonequilibrium thermodynamic calculations
+long-description = file:README.md
+long-description-content-type = text/markdown
+keywords = python
+home-page = https://github.com/gecrooks/disorder/
+author = Gavin E. Crooks
+author-email = gec@threeplusone.com
+license = Apache-2.0
+license-file = LICENSE
 
 # https://pypi.org/classifiers/
 Classifiers=


### PR DESCRIPTION
For no apparent reason, setuptools v53.1.0  no longer recognizing the "Name" metadata key. Must be lowercase "name".